### PR TITLE
Lua error handler

### DIFF
--- a/examples/error_handling.cr
+++ b/examples/error_handling.cr
@@ -1,0 +1,21 @@
+require "../src/lua"
+
+begin
+  Lua.run %q{
+    function runtime_error(x, y)
+      return x + y
+    end
+
+    runtime_error("blah", 10)
+  }
+rescue e : Lua::RuntimeError
+  puts e.message
+  puts e.traceback
+end
+
+# =>
+# [string "lua_chunk"]:3: attempt to perform arithmetic on a string value (local 'x')
+# stack traceback:
+#         [string "lua_chunk"]:3: in metamethod '__add'
+#         [string "lua_chunk"]:3: in function 'runtime_error'
+#         [string "lua_chunk"]:6: in main chunk

--- a/spec/fixtures/sample.lua
+++ b/spec/fixtures/sample.lua
@@ -10,4 +10,4 @@ function maximum (a)
   return m, mi
 end
 
-return(maximum({8,10,23,12,5}))     --> 23   3
+return(maximum({8,10,23,12,5})) --> 23, 3

--- a/spec/lua/stack/chunk_spec.cr
+++ b/spec/lua/stack/chunk_spec.cr
@@ -31,7 +31,7 @@ module Lua::StackMixin
         s = Stack.new
         s.run(%q{ return nil }).should eq nil
         s.run(%q{ return "a" }).should eq "a"
-        s.run(%q{ return false }).should eq nil
+        s.run(%q{ return false }).should eq false
         s.run(%q{ return true }).should eq true
         s.run(%q{ return 100 }).should eq 100
         s.run(%q{ a = {}; a[1] = "a"; return a }).as(Lua::Table)[1].should eq "a"

--- a/spec/lua/stack/chunk_spec.cr
+++ b/spec/lua/stack/chunk_spec.cr
@@ -51,7 +51,7 @@ module Lua::StackMixin
 
       it "removes chunk and results from the stack" do
         s = Stack.new.tap(&.<< false)
-        s.run("spec/fixtures/sample.lua")
+        s.run File.new("spec/fixtures/sample.lua")
         s.size.should eq 1
         s[1].should eq false
       end

--- a/spec/lua/stack/error_handling_spec.cr
+++ b/spec/lua/stack/error_handling_spec.cr
@@ -1,0 +1,18 @@
+require "../../spec_helper"
+
+module Lua::StackMixin
+  describe ErrorHandling do
+    describe "#set_error_handler" do
+      it "sets the Lua error handler by lua chunk" do
+        stack = Stack.new.tap &.set_error_handler %q{
+          return function(e)
+            return("something went wrong: " .. e)
+          end
+        }
+
+        stack.run "raise('Blah!')"
+        # TODO:
+      end
+    end
+  end
+end

--- a/spec/lua/stack/error_handling_spec.cr
+++ b/spec/lua/stack/error_handling_spec.cr
@@ -6,12 +6,13 @@ module Lua::StackMixin
       it "sets the Lua error handler by lua chunk" do
         stack = Stack.new.tap &.set_error_handler %q{
           return function(e)
-            return("something went wrong: " .. e)
+            return e
           end
         }
 
-        stack.run "raise('Blah!')"
-        # TODO:
+        expect_raises RuntimeError, "attempt to call a nil value (global 'raise')" do
+          stack.run "raise('Blah!')"
+        end
       end
     end
   end

--- a/spec/lua/stack/error_handling_spec.cr
+++ b/spec/lua/stack/error_handling_spec.cr
@@ -2,18 +2,48 @@ require "../../spec_helper"
 
 module Lua::StackMixin
   describe ErrorHandling do
-    describe "#set_error_handler" do
-      it "sets the Lua error handler by lua chunk" do
-        stack = Stack.new.tap &.set_error_handler %q{
-          return function(e)
-            return e
-          end
-        }
-
-        expect_raises RuntimeError, "attempt to call a nil value (global 'raise')" do
-          stack.run "raise('Blah!')"
-        end
+    it "cat catch lua syntax error" do
+      expect_raises RuntimeError, "attempt to call a nil value (global 'raise')" do
+        Lua.run "raise('Blah!')"
       end
+    end
+
+    it "can catch lua stack overflow" do
+      expect_raises RuntimeError, "stack overflow" do
+        Lua.run %q{
+          function s()
+            s()
+          end
+          s()
+        }
+      end
+    end
+
+    it "can give you a lua error message" do
+      stack = Stack.new
+      expect_raises RuntimeError, "attempt to perform arithmetic on a string value" do
+        stack.run %q{
+          s = "a" + 1
+        }
+      end
+    end
+
+    it "can give you a lua traceback" do
+      stack = Stack.new
+      expect_raises RuntimeError, "attempt to perform arithmetic on a string value" do
+        stack.run %q{
+          s = function()
+            return "a" + 1
+          end
+
+          print(s())
+        }
+      end.traceback.should eq <<-STACK
+      stack traceback:
+      \t[string "lua_chunk"]:3: in metamethod '__add'
+      \t[string "lua_chunk"]:3: in function 's'
+      \t[string "lua_chunk"]:6: in main chunk
+      STACK
     end
   end
 end

--- a/src/lua/constants.cr
+++ b/src/lua/constants.cr
@@ -19,4 +19,12 @@ module Lua
   REGISTRYINDEX = -1001000
 
   MULTRET = -1
+
+  enum CALL
+    OK      = 0
+    ERRRUN  = 2
+    ERRMEM  = 4
+    ERRGCMM = 5
+    ERRERR  = 6
+  end
 end

--- a/src/lua/exceptions.cr
+++ b/src/lua/exceptions.cr
@@ -1,6 +1,8 @@
 module Lua
   class LuaError < Exception
-    def initialize(@message : String = message)
+    getter traceback
+
+    def initialize(@message = message, @traceback : String? = traceback)
     end
   end
 

--- a/src/lua/exceptions.cr
+++ b/src/lua/exceptions.cr
@@ -1,0 +1,14 @@
+module Lua
+  class LuaError < Exception
+    def initialize(@message : String = message)
+    end
+  end
+
+  class RuntimeError < LuaError; end
+
+  class MemoryError < LuaError; end
+
+  class ErrorHandlerError < LuaError; end
+
+  class GCError < LuaError; end
+end

--- a/src/lua/object.cr
+++ b/src/lua/object.cr
@@ -5,12 +5,18 @@ module Lua
     def initialize(@stack : Stack = stack, @ref : Int32? = ref)
     end
 
-    def preload
-      LibLua.rawgeti(@stack.state, Lua::REGISTRYINDEX, ref) unless ref.nil?
+    # Loads Lua object onto the stack from registry, yields it's
+    # position (stack top) and removes object from the stack again.
+    # Used internally to ensure the Lua object is always accessible.
+    protected def preload
+      copy_to_stack if ref
       yield @stack.size
     ensure
-      @stack.pop unless ref.nil?
-      nil
+      @stack.pop if ref
+    end
+
+    protected def copy_to_stack
+      LibLua.rawgeti(@stack.state, Lua::REGISTRYINDEX, ref)
     end
   end
 end

--- a/src/lua/stack.cr
+++ b/src/lua/stack.cr
@@ -2,10 +2,11 @@ require "./stack/*"
 
 module Lua
   class Stack
-    include StackMixin::Registry
     include StackMixin::Type
     include StackMixin::Table
     include StackMixin::Chunk
+    include StackMixin::Registry
+    include StackMixin::ErrorHandling
 
     getter! state
 
@@ -23,7 +24,7 @@ module Lua
       LibLua.l_openlibs(@state)
     end
 
-    # Destroys all objects in the given Lua state
+    # Destroys all objects in the given Lua state.
     #
     # ```
     # stack = Lua::Stack.new

--- a/src/lua/stack.cr
+++ b/src/lua/stack.cr
@@ -22,6 +22,12 @@ module Lua
     def initialize
       @state = LibLua.l_newstate
       LibLua.l_openlibs(@state)
+
+      set_error_handler %q{
+        return function(e)
+          return { message = e, traceback = debug.traceback() }
+        end
+      }
     end
 
     # Destroys all objects in the given Lua state.

--- a/src/lua/stack/chunk.cr
+++ b/src/lua/stack/chunk.cr
@@ -12,7 +12,7 @@ module Lua
     # } # => 8
     # ```
     def run(buff : String)
-      LibLua.l_loadbufferx @state, buff, buff.size, "lua_code_chunk", nil
+      LibLua.l_loadbufferx @state, buff, buff.size, "lua_chunk", nil
       call_and_return size
     end
 
@@ -32,7 +32,8 @@ module Lua
       error_handler = self.load_error_handler initial_size
 
       args.each { |a| self.<< a }
-      LibLua.pcallk @state, args.size, Lua::MULTRET, 1, error_handler, nil
+      call = CALL.new LibLua.pcallk(@state, args.size, Lua::MULTRET, 1, error_handler, nil)
+      raise self.error(call) if call != CALL::OK
 
       elements = (initial_size..size).map { pop }
       elements.size > 1 ? elements : elements.first?

--- a/src/lua/stack/error_handling.cr
+++ b/src/lua/stack/error_handling.cr
@@ -20,6 +20,17 @@ module Lua::StackMixin
       end
     end
 
+    protected def error(type : CALL, message = self.pop.as(String))
+      case type
+      when CALL::ERRRUN  then RuntimeError.new message
+      when CALL::ERRMEM  then MemoryError.new message
+      when CALL::ERRGCMM then GCError.new message
+      when CALL::ERRERR  then ErrorHandlerError.new message
+      else
+        LuaError.new message
+      end
+    end
+
     # Loads handler onto the stack at the given position.
     # Returns 0 if handler not loaded.
     #

--- a/src/lua/stack/error_handling.cr
+++ b/src/lua/stack/error_handling.cr
@@ -1,0 +1,43 @@
+module Lua::StackMixin
+  module ErrorHandling
+    getter error_handler : Function?
+
+    # Sets the Lua error handler by lua chunk. The chunk
+    # should return a function that accepts error object.
+    #
+    # ```
+    # stack.set_error_handler %q{
+    #   return function(e)
+    #     print("error happened: " .. e)
+    #   end
+    # }
+    # ```
+    def set_error_handler(chunk : String)
+      if (res = run chunk).is_a?(Function)
+        @error_handler = res
+      else
+        raise ArgumentError.new("lua chunk need to return a function:\n #{chunk}")
+      end
+    end
+
+    # Loads handler onto the stack at the given position.
+    # Returns 0 if handler not loaded.
+    #
+    # ```
+    # stack.set_error_handler %q{
+    #   return function(e)
+    #     print("error happened: " .. e)
+    #   end
+    # }
+    # stack.load_error_handler(stack.size - 1) # => loads handler at top - 1 position
+    # ```
+    protected def load_error_handler(pos : Int)
+      if error_handler = @error_handler
+        error_handler.copy_to_stack   # place it at top
+        LibLua.rotate @state, pos, -1 # place it at pos
+        return pos
+      end
+      0
+    end
+  end
+end


### PR DESCRIPTION
Closes #7 
```crystal
require "../src/lua"

begin
  Lua.run %q{
    function runtime_error(x, y)
      return x + y
    end

    runtime_error("blah", 10)
  }
rescue e : Lua::RuntimeError
  puts e.message
  puts e.traceback
end

# =>
# [string "lua_chunk"]:3: attempt to perform arithmetic on a string value (local 'x')
# stack traceback:
#         [string "lua_chunk"]:3: in metamethod '__add'
#         [string "lua_chunk"]:3: in function 'runtime_error'
#         [string "lua_chunk"]:6: in main chunk

```