### PR TITLE
Fix specs for newest Crystal version

### DIFF
--- a/spec/lua/stack_spec.cr
+++ b/spec/lua/stack_spec.cr
@@ -80,7 +80,9 @@ module Lua
 
       it "raises error when it is a wrong object" do
         s = Stack.new
-        expect_raises { s << Exception.new }
+        expect_raises Exception do
+          s << Exception.new
+        end
       end
 
       it "accepts custom object that responds to :to_lua" do


### PR DESCRIPTION
The `expect_raises` without type argument has been removed for 0.24.0.

As the `expect_raises` with a type argument existed prior 0.24.0, it is safe to merge this before 0.24.0 or 0.24.1 is officially released.