### PR TITLE
Make lib compatible with current Crystal lang

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,3 +1,6 @@
 LineLength:
   # Disallows lines longer that MaxLength number of symbols.
   MaxLength: 150
+Metrics/CyclomaticComplexity:
+  Enabled: true
+  MaxComplexity: 15

--- a/shard.yml
+++ b/shard.yml
@@ -11,4 +11,4 @@ license: MIT
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: 0.7.0
+    version: '~> 0.10'

--- a/src/lua/object/table.cr
+++ b/src/lua/object/table.cr
@@ -60,7 +60,7 @@ module Lua
 
     # Implements Iterable
     def each : Iterator
-      return this
+      self
     end
 
     # Converts this table to Crystal hash.

--- a/src/lua/object/table.cr
+++ b/src/lua/object/table.cr
@@ -58,6 +58,11 @@ module Lua
       end
     end
 
+    # Implements Iterable
+    def each : Iterator
+      return this
+    end
+
     # Converts this table to Crystal hash.
     #
     # ```

--- a/src/lua/stack.cr
+++ b/src/lua/stack.cr
@@ -136,6 +136,7 @@ module Lua
     # ```
     #
     def to_s(io : IO)
+      return "" if size == 0
       io << String.build do |acc|
         l = size
         pad = Math.log10(l).to_i + 1


### PR DESCRIPTION
Tested on current Crystal 0.31.1 i have error:
Error: abstract `def Iterable(T)#each()` must be implemented by Lua::Table

This PR fix it.