### PR TITLE
Crystal Api for Lua global variables

### DIFF
--- a/spec/lua/stack/util_spec.cr
+++ b/spec/lua/stack/util_spec.cr
@@ -9,5 +9,59 @@ module Lua::StackMixin
         (v > 0).should be_true
       end
     end
+
+    describe "#set_global" do
+      it "returns the string concated from global strings" do
+        s = Stack.new
+        s.set_global("h", "Hello")
+        s.set_global("w", "world")
+        r = s.run "return h .. ' ' .. w"
+        r.to_s.should eq "Hello world"
+      end
+
+      it "returns the string concated from global Hash" do
+        s = Stack.new
+        obj = {"h" => "Hello", "w" => "world"}
+        s.set_global("o", obj)
+        r = s.run "return o['h'] .. ' ' .. o['w']"
+        r.to_s.should eq "Hello world"
+      end
+
+      it "cannot modify passed global Hash" do
+        s = Stack.new
+        obj = {"h" => "Hello", "w" => "Crystal"}
+        s.set_global("o", obj)
+        s.run "o['w']='Lua'"
+        obj["w"].should eq "Crystal"
+      end
+
+      it "read global lua defined variable" do
+        s = Stack.new
+        s.run "g = 'Lua'"
+        g = s.get_global("g")
+        g.should eq "Lua"
+      end
+
+      it "read modified global string" do
+        s = Stack.new
+        g = "Crystal"
+        s.set_global("g", g)
+        r = s.run "l = g; g = 'Lua';return l"
+        g.should eq "Crystal"
+        r.to_s.should eq "Crystal"
+        g = s.get_global("g")
+        g.should eq "Lua"
+      end
+
+      it "read modified global hash" do
+        s = Stack.new
+        obj = {"h" => "Hello", "w" => "Crystal"}
+        s.set_global("o", obj)
+        s.run "o['w']='Lua'"
+        obj["w"].should eq "Crystal"
+        obj = s.get_global("o").as(Table).to_h
+        obj["w"].should eq "Lua"
+      end
+    end
   end
 end

--- a/src/lua/stack/util.cr
+++ b/src/lua/stack/util.cr
@@ -16,6 +16,18 @@ module Lua
       ar
     end
 
+    # assign a value to a lua global variable with the name to value
+    def set_global(name : String, value)
+      self << value
+      LibLua.setglobal(@state, name)
+    end
+
+    # gets a value of the global with the name
+    def get_global(name : String)
+      LibLua.getglobal(@state, name)
+      pop
+    end
+
     protected def check_lua_supported
       if (ver = version) < 503
         raise RuntimeError.new "Lua #{ver} not supported. Try Lua 5.3 or higher."


### PR DESCRIPTION
It's currently supported from Crystal code by calling:
```
s = Stack.new
s << value
LibLua.setglobal(s.state, name)
```
but it's very confusing for newcomers, you must know that stack has state variable and know internal lua apis in LibLua. It's better to have dedicated api methods on stack.