### PR TITLE
Make compatible with Lua 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: crystal
 
 before_install:
-  - curl -R -O http://www.lua.org/ftp/lua-5.3.4.tar.gz
-  - tar zxf lua-5.3.4.tar.gz
-  - cd lua-5.3.4
+  - curl -R -O http://www.lua.org/ftp/lua-5.4.2.tar.gz
+  - tar zxf lua-5.4.2.tar.gz
+  - cd lua-5.4.2
   - sudo make linux install
   - cd ../
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bindings to liblua and a wrapper around it. **UNDER CONSTRUCTION** :construction:
 
-Only [Lua 5.3](http://www.lua.org/ftp/) or higher is supported.
+Only [Lua 5.4](http://www.lua.org/ftp/) or higher is supported.
 
 ## Installation
 

--- a/spec/lua/stack/error_handling_spec.cr
+++ b/spec/lua/stack/error_handling_spec.cr
@@ -38,7 +38,7 @@ module Lua::StackMixin
 
     it "can give you a lua error message" do
       stack = Stack.new
-      expect_raises RuntimeError, "attempt to perform arithmetic on a string value" do
+      expect_raises RuntimeError, "attempt to add a 'string' with a 'number'" do
         stack.run %q{
           s = "a" + 1
         }
@@ -47,7 +47,7 @@ module Lua::StackMixin
 
     it "can give you a lua traceback" do
       stack = Stack.new
-      expect_raises RuntimeError, "attempt to perform arithmetic on a string value" do
+      expect_raises RuntimeError, "attempt to add a 'string' with a 'number'" do
         stack.run %q{
           s = function()
             return "a" + 1
@@ -57,7 +57,8 @@ module Lua::StackMixin
         }
       end.traceback.should eq <<-STACK
       stack traceback:
-      \t[string "error handler"]:3: in metamethod '__add'
+      \t[string "error handler"]:3: in function <[string "error handler"]:2>
+      \t[C]: in metamethod 'add'
       \t[string "s = function()..."]:3: in function 's'
       \t[string "s = function()..."]:6: in main chunk
       STACK
@@ -70,7 +71,7 @@ module Lua::StackMixin
           return x + y
         end
       }
-      expect_raises RuntimeError, "attempt to perform arithmetic on a string value (local 'x')" do
+      expect_raises RuntimeError, "attempt to add a 'string' with a 'number'" do
         sum.as(Lua::Function).call("a", 3)
       end
     end

--- a/src/lua/constants.cr
+++ b/src/lua/constants.cr
@@ -20,9 +20,8 @@ module Lua
     ERRRUN    = 2
     ERRSYNTAX = 3
     ERRMEM    = 4
-    ERRGCMM   = 5
-    ERRERR    = 6
-    ERRFILE   = 7
+    ERRERR    = 5
+    ERRFILE   = 6
   end
 
   REFNIL        =         -1

--- a/src/lua/exceptions.cr
+++ b/src/lua/exceptions.cr
@@ -14,7 +14,5 @@ module Lua
 
   class ErrorHandlerError < LuaError; end
 
-  class GCError < LuaError; end
-
   class FileError < LuaError; end
 end

--- a/src/lua/liblua.cr
+++ b/src/lua/liblua.cr
@@ -107,9 +107,9 @@ lib LibLua
   fun rawgeti = lua_rawgeti(l : State, idx : LibC::Int, n : LibC::Int) : LibC::Int
   fun rawgetp = lua_rawgetp(l : State, idx : LibC::Int, p : Void*)
   fun createtable = lua_createtable(l : State, narr : LibC::Int, nrec : LibC::Int)
-  fun newuserdata = lua_newuserdata(l : State, sz : LibC::SizeT) : Void*
+  fun newuserdatauv = lua_newuserdatauv(l : State, sz : LibC::SizeT, nuvalue : LibC::Int) : Void*
   fun getmetatable = lua_getmetatable(l : State, objindex : LibC::Int) : LibC::Int
-  fun getuservalue = lua_getuservalue(l : State, idx : LibC::Int)
+  fun getiuservalue = lua_getiuservalue(l : State, idx : LibC::Int, n : LibC::Int) : LibC::Int
   fun setglobal = lua_setglobal(l : State, var : LibC::Char*)
   fun settable = lua_settable(l : State, idx : LibC::Int)
   fun setfield = lua_setfield(l : State, idx : LibC::Int, k : LibC::Char*)
@@ -117,7 +117,7 @@ lib LibLua
   fun rawseti = lua_rawseti(l : State, idx : LibC::Int, n : LibC::Int)
   fun rawsetp = lua_rawsetp(l : State, idx : LibC::Int, p : Void*)
   fun setmetatable = lua_setmetatable(l : State, objindex : LibC::Int) : LibC::Int
-  fun setuservalue = lua_setuservalue(l : State, idx : LibC::Int)
+  fun setiuservalue = lua_setiuservalue(l : State, idx : LibC::Int, n : LibC::Int) : LibC::Int
   fun callk = lua_callk(l : State, nargs : LibC::Int, nresults : LibC::Int, ctx : LibC::Int, k : CFunction)
   fun getctx = lua_getctx(l : State, ctx : LibC::Int*) : LibC::Int
   fun pcallk = lua_pcallk(l : State, nargs : LibC::Int, nresults : LibC::Int, errfunc : LibC::Int, ctx : LibC::Int, k : CFunction) : LibC::Int

--- a/src/lua/liblua.cr
+++ b/src/lua/liblua.cr
@@ -74,7 +74,7 @@ lib LibLua
   fun close = lua_close(l : State)
   fun newthread = lua_newthread(l : State) : State
   fun atpanic = lua_atpanic(l : State, panicf : CFunction) : CFunction
-  fun version = lua_version(l : State) : Number*
+  fun version = lua_version(l : State) : Number
   fun absindex = lua_absindex(l : State, idx : LibC::Int) : LibC::Int
   fun gettop = lua_gettop(l : State) : LibC::Int
   fun settop = lua_settop(l : State, idx : LibC::Int)

--- a/src/lua/liblua.cr
+++ b/src/lua/liblua.cr
@@ -123,7 +123,7 @@ lib LibLua
   fun pcallk = lua_pcallk(l : State, nargs : LibC::Int, nresults : LibC::Int, errfunc : LibC::Int, ctx : LibC::Int, k : CFunction) : LibC::Int
   fun load = lua_load(l : State, reader : Reader, dt : Void*, chunkname : LibC::Char*, mode : LibC::Char*) : LibC::Int
   fun yieldk = lua_yieldk(l : State, nresults : LibC::Int, ctx : LibC::Int, k : CFunction) : LibC::Int
-  fun resume = lua_resume(l : State, from : State, narg : LibC::Int) : LibC::Int
+  fun resume = lua_resume(l : State, from : State, narg : LibC::Int, nresults : LibC::Int*) : LibC::Int
   fun status = lua_status(l : State) : LibC::Int
   fun gc = lua_gc(l : State, what : LibC::Int, data : LibC::Int) : LibC::Int
   fun error = lua_error(l : State) : LibC::Int

--- a/src/lua/liblua.cr
+++ b/src/lua/liblua.cr
@@ -18,6 +18,7 @@ lib LibLua
     namewhat : LibC::Char*
     what : LibC::Char*
     source : LibC::Char*
+    srclen : LibC::SizeT
     currentline : LibC::Int
     linedefined : LibC::Int
     lastlinedefined : LibC::Int
@@ -25,6 +26,8 @@ lib LibLua
     nparams : UInt8
     isvararg : LibC::Char
     istailcall : LibC::Char
+    ftransfer : LibC::UShort
+    ntransfer : LibC::UShort
     short_src : LibC::Char[60]
     i_ci : Void*
   end

--- a/src/lua/stack/class_support.cr
+++ b/src/lua/stack/class_support.cr
@@ -11,21 +11,21 @@ module Lua
         # Set __index
         proc = ->LuaCallable.__index(LibLua::State)
         self << INDEX_METAMETHOD             # push method name on stack
-        LibLua.pushcclosure(@state, proc, 0) # pointer to function on stack
+        pushclosure(proc)                    # pointer to function on stack
         LibLua.settable(@state, -3)
         # Set __gc
         proc = ->LuaCallable.__gc(LibLua::State)
         self << GC_METAMETHOD                # push method name on stack
-        LibLua.pushcclosure(@state, proc, 0) # pointer to function on stack
+        pushclosure(proc)                    # pointer to function on stack
         LibLua.settable(@state, -3)
         # set __newindex
         proc = ->LuaCallable.__newindex(LibLua::State)
         self << NEW_INDEX_METAMETHOD         # push method name on stack
-        LibLua.pushcclosure(@state, proc, 0) # pointer to function on stack
+        pushclosure(proc)                    # pointer to function on stack
         LibLua.settable(@state, -3)
         proc = ->type.__new(LibLua::State)
         self << NEW_OBJECT_METAKEY           # push method name on stack
-        LibLua.pushcclosure(@state, proc, 0) # pointer to function on stack
+        pushclosure(proc)                    # pointer to function on stack
         LibLua.settable(@state, -3)
         self << CRYSTAL_BASE_TYPE_METAKEY
         self << LuaCallable.name

--- a/src/lua/stack/class_support.cr
+++ b/src/lua/stack/class_support.cr
@@ -1,8 +1,8 @@
 module Lua
   class Object
     macro methods
-          {{ @type.methods.map &.name.stringify }}
-        end
+      {{ @type.methods.map &.name.stringify }}
+    end
   end
 
   module StackMixin::ClassSupport
@@ -35,7 +35,7 @@ module Lua
 
     def pushobject(a : LuaCallable)
       # pushes onto the stack a new full userdata with the block address, and returns this address
-      p = LibLua.newuserdata(@state, sizeof(Pointer(UInt64))) # address of user data
+      p = LibLua.newuserdatauv(@state, sizeof(Pointer(UInt64)), 1) # address of user data
       user_data = p.as(Pointer(UInt64))
       user_data.value = a.object_id
       pushmetatable(a.class)

--- a/src/lua/stack/coroutine_support.cr
+++ b/src/lua/stack/coroutine_support.cr
@@ -4,7 +4,7 @@ module Lua::StackMixin
     # that state and function `f`
     def newthread(f : Function)
       LibLua.newthread(@state)
-      pop.as(Coroutine).tap { |c| c.function = f }
+      pop.as(Coroutine).tap(&.function=(f))
     end
 
     # Starts and resumes a coroutine in the given thread

--- a/src/lua/stack/coroutine_support.cr
+++ b/src/lua/stack/coroutine_support.cr
@@ -12,7 +12,8 @@ module Lua::StackMixin
       thread_pos = size
       args.each { |a| self.<< a }
 
-      res = CALL.new LibLua.resume(@state, nil, args.size)
+      nres = 0
+      res = CALL.new LibLua.resume(@state, nil, args.size, pointerof(nres))
       raise error(res, pop) if res > CALL::YIELD
 
       pick_results thread_pos

--- a/src/lua/stack/error_handling.cr
+++ b/src/lua/stack/error_handling.cr
@@ -45,7 +45,6 @@ module Lua::StackMixin
       when .errrun?    then RuntimeError.new message, traceback
       when .errsyntax? then SyntaxError.new message, traceback
       when .errmem?    then MemoryError.new message, traceback
-      when .errgcmm?   then GCError.new message, traceback
       when .errerr?    then ErrorHandlerError.new message, traceback
       when .errfile?   then FileError.new message, traceback
       else

--- a/src/lua/stack/util.cr
+++ b/src/lua/stack/util.cr
@@ -6,7 +6,7 @@ module Lua
     # state.version # => 503.0
     # ```
     def version
-      LibLua.version(@state).value
+      LibLua.version(@state)
     end
 
     # Gets information about a specific function or function invocation.

--- a/src/lua/stack/util.cr
+++ b/src/lua/stack/util.cr
@@ -30,7 +30,7 @@ module Lua
 
     protected def check_lua_supported
       if (ver = version) < 504
-        raise RuntimeError.new "Lua #{ver} not supported. Try Lua 5.3 or higher."
+        raise RuntimeError.new "Lua #{ver} not supported. Try Lua 5.4 or higher."
       end
     end
 

--- a/src/lua/stack/util.cr
+++ b/src/lua/stack/util.cr
@@ -29,7 +29,7 @@ module Lua
     end
 
     protected def check_lua_supported
-      if (ver = version) < 503
+      if (ver = version) < 504
         raise RuntimeError.new "Lua #{ver} not supported. Try Lua 5.3 or higher."
       end
     end


### PR DESCRIPTION
This pull request makes the Lib compatible with the changes from Lua 5.4 (https://github.com/veelenga/lua.cr/issues/35), but removes support for Lua 5.3.
- Updated `LibLua` `fun`s (and associated usages) with their new signatures
- Updated `LibLua::Debug` with new structure

Should this go in a different branch?