### PR TITLE
[WIP] Adding new register_function macro

### DIFF
--- a/spec/lua/stack_spec.cr
+++ b/spec/lua/stack_spec.cr
@@ -184,6 +184,28 @@ module Lua
         stack.size.should eq 1
       end
     end
+
+    describe "#register_function" do
+      it "creates a new Lua function" do
+        stack = Stack.new
+        Stack.register_function stack, "crystal_debug", ->(value : String) do
+          value
+        end
+
+        result = stack.run %(return crystal_debug("hello"))
+        result.should eq("hello")
+      end
+
+      it "creates a new Lua function with two args" do
+        stack = Stack.new
+        Stack.register_function stack, "crystal_add", ->(x : Float64, y : Float64) do
+          x + y
+        end
+
+        result = stack.run "return crystal_add(1, 2)"
+        result.should eq(3)
+      end
+    end
   end
 
   private class LuaReporter

--- a/src/lua/stack.cr
+++ b/src/lua/stack.cr
@@ -11,6 +11,7 @@ module Lua
     include StackMixin::CoroutineSupport
     include StackMixin::StandardLibraries
     include StackMixin::ClassSupport
+    include StackMixin::RegisterFunction
 
     getter state
     getter libs = Set(Symbol).new

--- a/src/lua/stack/register_function.cr
+++ b/src/lua/stack/register_function.cr
@@ -1,0 +1,26 @@
+module Lua
+  module StackMixin::RegisterFunction
+    macro included
+      macro register_function(stack, name, proc)
+        {% verbatim do %}
+        proc = ->(state : LibLua::State) {
+          {% for arg, index in proc.args %}
+            {{ arg.name }} = LibLua.tonumberx(state, {{ index + 1 }}, nil)
+          {% end %}
+
+          # push result to stack
+          LibLua.pushnumber(state, {{ proc.body }})
+
+          1 # number of results
+        }
+
+        # push crystal proc onto the stack
+        LibLua.pushcclosure({{ stack.id }}.state, proc, 0)
+
+        # give it a name
+        LibLua.setglobal({{ stack.id }}.state, {{ name }})
+        {% end %}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #15

This is currently just WIP because I don't really understand the Lua internals. I know the implementation will need some work as it currently only works with `Float64`. 

With this, you'll be able to define a proc in Crystal, and then name it. Then from Lua you will be able to execute that proc as a function.

```crystal
lua = Lua.load
Stack.register_function lua, "crystal_add", ->(x : Float64, y : Float64) do
  x + y
end

result = my_stack.run <<-LUA
return crystal_add(1, 2)
LUA

result == 3
```