### PR TITLE
fix: detect REGISTRYINDEX at runtime for Lua 5.4/5.5 compat

### DIFF
--- a/src/lua/callable.cr
+++ b/src/lua/callable.cr
@@ -169,8 +169,8 @@ module LuaCallable
   end
 
   def self.__call(state : LibLua::State) : Int32
-    data = LibLua.topointer(state, Lua::REGISTRYINDEX - 1) # lua_upvalueindex(1)
-    ptr = LibLua.topointer(state, Lua::REGISTRYINDEX - 2)  # lua_upvalueindex(2)
+    data = LibLua.topointer(state, Lua.registry_index - 1) # lua_upvalueindex(1)
+    ptr = LibLua.topointer(state, Lua.registry_index - 2)  # lua_upvalueindex(2)
     proc = Proc(LibLua::State, Int32).new(ptr, data)
     proc.call(state)
   end

--- a/src/lua/constants.cr
+++ b/src/lua/constants.cr
@@ -24,9 +24,21 @@ module Lua
     ERRFILE   = 6
   end
 
-  REFNIL        = -1
-  NOREF         = -2
-  REGISTRYINDEX = -(Int32::MAX // 2 + 1000)
+  REFNIL = -1
+  NOREF  = -2
+
+  # Detect REGISTRYINDEX from the linked Lua version.
+  # Lua 5.4: -(1_000_000 + 1000), Lua 5.5+: -(INT_MAX/2 + 1000)
+  @@registry_index : Int32 = begin
+    state = LibLua.l_newstate
+    ver = LibLua.version(state)
+    LibLua.close(state)
+    ver >= 505 ? -(Int32::MAX // 2 + 1000) : -1_001_000
+  end
+
+  def self.registry_index : Int32
+    @@registry_index
+  end
 
   MULTRET = -1
 

--- a/src/lua/stack/registry.cr
+++ b/src/lua/stack/registry.cr
@@ -5,17 +5,17 @@ module Lua
     # and removes it from the stack. Returns a reference.
     def reference(pos)
       LibLua.pushvalue(@state, pos)
-      LibLua.l_ref(@state, Lua::REGISTRYINDEX)
+      LibLua.l_ref(@state, Lua.registry_index)
     end
 
     # Retrieves an object referred by reference.
     def rawgeti(ref)
-      TYPE.new LibLua.rawgeti(@state, Lua::REGISTRYINDEX, ref)
+      TYPE.new LibLua.rawgeti(@state, Lua.registry_index, ref)
     end
 
     # Frees a reference and its associated object.
     def unref(ref)
-      LibLua.l_unref(@state, Lua::REGISTRYINDEX, ref)
+      LibLua.l_unref(@state, Lua.registry_index, ref)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Detect the linked Lua version at startup and compute the correct `REGISTRYINDEX` value
- Lua 5.4 uses `-1001000`, Lua 5.5 uses `-(INT_MAX/2 + 1000)` — using the wrong value causes a segfault in `lua_rawgeti`

## Test plan
- [ ] CI passes with Lua 5.4 (Ubuntu)
- [ ] Local specs pass with Lua 5.5 (macOS)